### PR TITLE
Feat: localize all hardcoded Russian strings via Localizable.strings

### DIFF
--- a/MovieQuiz.xcodeproj/project.pbxproj
+++ b/MovieQuiz.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		AD5EE5DE284D7887003966EF /* UIColor+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5EE5DD284D7887003966EF /* UIColor+Extensions.swift */; };
 		AD77F5742857F8810062FB14 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD77F5732857F8810062FB14 /* Date+Extensions.swift */; };
 		AD7AFA552836189F00399704 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7AFA542836189F00399704 /* Array+Extensions.swift */; };
+		A16EA88AF095A3C66DEB98F5 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A8BD1ADDE20AE47DC20CE9B4 /* Localizable.strings */; };
+		747A62B9CF05D8AA128E87FB /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = ADB6039856A4057D04DC8642 /* Localizable.strings */; };
+		F7BB1E40D73FB48D7C5988B1 /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D7F15E801773A75F193586 /* Localization.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +37,9 @@
 		AD5EE5DD284D7887003966EF /* UIColor+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+Extensions.swift"; sourceTree = "<group>"; };
 		AD77F5732857F8810062FB14 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
 		AD7AFA542836189F00399704 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
+		A8BD1ADDE20AE47DC20CE9B4 /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Localizable; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		ADB6039856A4057D04DC8642 /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Localizable; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F2D7F15E801773A75F193586 /* Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Localization.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,6 +82,8 @@
 		8F4738332848DE46005DF65E /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				A8BD1ADDE20AE47DC20CE9B4 /* Localizable.strings (Base) */,
+				ADB6039856A4057D04DC8642 /* Localizable.strings (en) */,
 				53FC9BDD2B67D92C0089CEAA /* Fonts */,
 				AD1ABABC2831907F00B3E448 /* LaunchScreen.storyboard */,
 				AD1ABABA2831907F00B3E448 /* Assets.xcassets */,
@@ -103,6 +111,7 @@
 		AD1ABAB02831907B00B3E448 /* MovieQuiz */ = {
 			isa = PBXGroup;
 			children = (
+				F2D7F15E801773A75F193586 /* Localization.swift */,
 				8F4738322848DE2A005DF65E /* Presentation */,
 				ADF0CF75283FDAA10075F54D /* Helpers */,
 				8F4738332848DE46005DF65E /* Resources */,
@@ -181,6 +190,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A16EA88AF095A3C66DEB98F5 /* Localizable.strings in Resources */,
+				747A62B9CF05D8AA128E87FB /* Localizable.strings in Resources */,
 				AD1ABABE2831907F00B3E448 /* LaunchScreen.storyboard in Resources */,
 				53FC9BE12B67D95B0089CEAA /* YS Display-Medium.ttf in Resources */,
 				53FC9BE22B67D95B0089CEAA /* YS Display-Bold.ttf in Resources */,
@@ -201,6 +212,7 @@
 				AD1ABAB62831907B00B3E448 /* MovieQuizViewController.swift in Sources */,
 				AD77F5742857F8810062FB14 /* Date+Extensions.swift in Sources */,
 				AD1ABAB22831907B00B3E448 /* AppDelegate.swift in Sources */,
+				F7BB1E40D73FB48D7C5988B1 /* Localization.swift in Sources */,
 				AD1ABAB42831907B00B3E448 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MovieQuiz/Presentation/MovieQuizViewController.swift
+++ b/MovieQuiz/Presentation/MovieQuizViewController.swift
@@ -7,43 +7,43 @@ final class MovieQuizViewController: UIViewController {
     private let questions: [QuizQuestion] = [
         QuizQuestion(
             image: "The Godfather",
-            text: "Рейтинг этого фильма больше чем 6?",
+            text: L10n.questionText,
             correctAnswer: true),
         QuizQuestion(
             image: "The Dark Knight",
-            text: "Рейтинг этого фильма больше чем 6?",
+            text: L10n.questionText,
             correctAnswer: true),
         QuizQuestion(
             image: "Kill Bill",
-            text: "Рейтинг этого фильма больше чем 6?",
+            text: L10n.questionText,
             correctAnswer: true),
         QuizQuestion(
             image: "The Avengers",
-            text: "Рейтинг этого фильма больше чем 6?",
+            text: L10n.questionText,
             correctAnswer: true),
         QuizQuestion(
             image: "Deadpool",
-            text: "Рейтинг этого фильма больше чем 6?",
+            text: L10n.questionText,
             correctAnswer: true),
         QuizQuestion(
             image: "The Green Knight",
-            text: "Рейтинг этого фильма больше чем 6?",
+            text: L10n.questionText,
             correctAnswer: true),
         QuizQuestion(
             image: "Old",
-            text: "Рейтинг этого фильма больше чем 6?",
+            text: L10n.questionText,
             correctAnswer: false),
         QuizQuestion(
             image: "The Ice Age Adventures of Buck Wild",
-            text: "Рейтинг этого фильма больше чем 6?",
+            text: L10n.questionText,
             correctAnswer: false),
         QuizQuestion(
             image: "Tesla",
-            text: "Рейтинг этого фильма больше чем 6?",
+            text: L10n.questionText,
             correctAnswer: false),
         QuizQuestion(
             image: "Vivarium",
-            text: "Рейтинг этого фильма больше чем 6?",
+            text: L10n.questionText,
             correctAnswer: false),
     ]
 
@@ -105,15 +105,15 @@ final class MovieQuizViewController: UIViewController {
         // .image trait so VoiceOver announces "image" before the label.
         imageView.isAccessibilityElement = true
         imageView.accessibilityTraits = .image
-        imageView.accessibilityLabel = "Постер фильма"
+        imageView.accessibilityLabel = L10n.a11yPoster
 
         // Answer buttons. The storyboard buttons have no visible title, so
         // the accessibility label is the only thing VoiceOver users hear.
-        noButton.accessibilityLabel = "Нет"
-        noButton.accessibilityHint = "Ответить, что рейтинг фильма меньше или равен 6"
+        noButton.accessibilityLabel = L10n.a11yNoLabel
+        noButton.accessibilityHint = L10n.a11yNoHint
 
-        yesButton.accessibilityLabel = "Да"
-        yesButton.accessibilityHint = "Ответить, что рейтинг фильма больше 6"
+        yesButton.accessibilityLabel = L10n.a11yYesLabel
+        yesButton.accessibilityHint = L10n.a11yYesHint
     }
 
     // MARK: - Dynamic Type
@@ -203,11 +203,11 @@ final class MovieQuizViewController: UIViewController {
 
     private func showNextQuestionOrResults() {
         if currentQuestionIndex == questions.count - 1 {
-            let text = "Ваш результат: \(correctAnswers)/10"
+            let text = L10n.resultText(correct: correctAnswers, total: questions.count)
             let viewModel = QuizResultsViewModel(
-                title: "Этот раунд окончен!",
+                title: L10n.resultTitle,
                 text: text,
-                buttonText: "Сыграть ещё раз")
+                buttonText: L10n.resultReplay)
             show(quiz: viewModel)
         } else {
             currentQuestionIndex += 1
@@ -230,7 +230,7 @@ final class MovieQuizViewController: UIViewController {
         },
                           completion: nil)
         textLabel.text = step.question
-        counterLabel.text = step.questionNumber
+        counterLabel.text = L10n.counterText(current: currentQuestionIndex + 1, total: questions.count)
         enableAnswerButtons()
     }
 

--- a/MovieQuiz/Presentation/MovieQuizViewController.swift
+++ b/MovieQuiz/Presentation/MovieQuizViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 final class MovieQuizViewController: UIViewController {
     private var currentQuestionIndex = 0
     private var correctAnswers = 0
-    
+
     private let questions: [QuizQuestion] = [
         QuizQuestion(
             image: "The Godfather",
@@ -46,43 +46,137 @@ final class MovieQuizViewController: UIViewController {
             text: "Рейтинг этого фильма больше чем 6?",
             correctAnswer: false),
     ]
-    
+
     @IBOutlet private var noButton: UIButton!
     @IBOutlet private var yesButton: UIButton!
     @IBOutlet private var counterLabel: UILabel!
     @IBOutlet private var textLabel: UILabel!
     @IBOutlet private var imageView: UIImageView!
-    
+
     private struct ViewModel {
         let image: UIImage
         let question: String
         let questionNumber: String
     }
-    
+
     private struct QuizStepViewModel {
         let image: UIImage
         let question: String
         let questionNumber: String
     }
-    
+
     private struct QuizResultsViewModel {
         let title: String
         let text: String
         let buttonText: String
     }
-    
+
     private struct QuizQuestion {
         let image: String
         let text: String
         let correctAnswer: Bool
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupAccessibility()
+        setupDynamicTypeFonts()
         let currentQuestion = questions[currentQuestionIndex]
         show(quiz: convert(model: currentQuestion))
     }
-    
+
+    // MARK: - Accessibility
+
+    /// Configures VoiceOver labels, hints, and traits for every interactive
+    /// and informational UI element. The app's buttons have no visible title
+    /// (they live in a custom-themed storyboard) so without explicit labels
+    /// VoiceOver users have no way to distinguish the Yes / No answer.
+    private func setupAccessibility() {
+        // Question label: header so VoiceOver reads it before the question
+        // text, and the user can jump to it with the "Headings" rotor.
+        textLabel.isAccessibilityElement = true
+        textLabel.accessibilityTraits = .header
+
+        // Counter ("1/10"): header, distinct from the question itself.
+        counterLabel.isAccessibilityElement = true
+        counterLabel.accessibilityTraits = .header
+
+        // Question poster image: a single accessibility element with an
+        // .image trait so VoiceOver announces "image" before the label.
+        imageView.isAccessibilityElement = true
+        imageView.accessibilityTraits = .image
+        imageView.accessibilityLabel = "Постер фильма"
+
+        // Answer buttons. The storyboard buttons have no visible title, so
+        // the accessibility label is the only thing VoiceOver users hear.
+        noButton.accessibilityLabel = "Нет"
+        noButton.accessibilityHint = "Ответить, что рейтинг фильма меньше или равен 6"
+
+        yesButton.accessibilityLabel = "Да"
+        yesButton.accessibilityHint = "Ответить, что рейтинг фильма больше 6"
+    }
+
+    // MARK: - Dynamic Type
+
+    /// The app uses two custom YS Display fonts (set in the storyboard) and
+    /// one magic-number border width. iOS does not automatically scale
+    /// custom fonts with the user's preferred text size, so without this
+    /// the UI stays fixed-size and becomes unreadable for users who set a
+    /// larger Dynamic Type value in Settings.
+    ///
+    /// UIFontMetrics lets us keep the visual identity of the custom font
+    /// while honoring the user's accessibility text-size preference.
+    private func setupDynamicTypeFonts() {
+        // Counter ("1/10") — display size for an at-a-glance counter.
+        applyScaledFont(
+            to: counterLabel,
+            fontName: "YSDisplay-Medium",
+            fallbackSize: 20,
+            textStyle: .title3
+        )
+
+        // Question text — body size for readability.
+        applyScaledFont(
+            to: textLabel,
+            fontName: "YSDisplay-Medium",
+            fallbackSize: 23,
+            textStyle: .body
+        )
+
+        // Auto-resize label + border when Dynamic Type changes while the
+        // app is running.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(contentSizeCategoryDidChange),
+            name: UIContentSizeCategory.didChangeNotification,
+            object: nil
+        )
+    }
+
+    private func applyScaledFont(
+        to label: UILabel,
+        fontName: String,
+        fallbackSize: CGFloat,
+        textStyle: UIFontTextStyle
+    ) {
+        let baseFont = UIFont(name: fontName, size: fallbackSize) ?? UIFont.systemFont(ofSize: fallbackSize)
+        let scaled = UIFontMetrics(forTextStyle: textStyle).scaledFont(for: baseFont)
+        label.font = scaled
+        label.adjustsFontForContentSizeCategory = true
+    }
+
+    @objc private func contentSizeCategoryDidChange() {
+        // Re-apply fonts when the user changes the preferred content size
+        // while the app is in the background.
+        setupDynamicTypeFonts()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: - Quiz logic (unchanged)
+
     private func convert(model: QuizQuestion) -> QuizStepViewModel {
         let questionStep = QuizStepViewModel(
             image: UIImage(named: model.image) ?? UIImage(),
@@ -90,23 +184,23 @@ final class MovieQuizViewController: UIViewController {
             questionNumber: "\(currentQuestionIndex + 1)/\(questions.count)")
         return questionStep
     }
-    
+
     private func showAnswerResult(isCorrect: Bool) {
         if isCorrect {
             correctAnswers += 1
         }
-        
-        
+
+
         imageView.layer.masksToBounds = true
         imageView.layer.borderWidth = 8
         imageView.layer.borderColor = isCorrect ? UIColor.ypGreen.cgColor : UIColor.ypRed.cgColor
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
             guard let self = self else { return }
             self.showNextQuestionOrResults()
         }
     }
-    
+
     private func showNextQuestionOrResults() {
         if currentQuestionIndex == questions.count - 1 {
             let text = "Ваш результат: \(correctAnswers)/10"
@@ -122,10 +216,10 @@ final class MovieQuizViewController: UIViewController {
             show(quiz: viewModel)
         }
     }
-    
+
     private func show(quiz step: QuizStepViewModel) {
         let newImage = step.image
-        
+
         UIView.transition(with: imageView,
                           duration: 0,
                           options: .transitionCrossDissolve,
@@ -139,51 +233,51 @@ final class MovieQuizViewController: UIViewController {
         counterLabel.text = step.questionNumber
         enableAnswerButtons()
     }
-    
+
     private func show(quiz result: QuizResultsViewModel) {
         let alert = UIAlertController(
             title: result.title,
             message: result.text,
             preferredStyle: .alert)
-        
+
         let action = UIAlertAction(title: result.buttonText, style: .default) { [weak self] _ in
             guard let self = self else { return }
             self.currentQuestionIndex = 0
             self.correctAnswers = 0
-            
+
             let firstQuestion = self.questions[self.currentQuestionIndex]
             let viewModel = self.convert(model: firstQuestion)
             self.show(quiz: viewModel)
         }
-        
+
         alert.addAction(action)
-        
+
         present(alert, animated: true, completion: nil)
     }
-    
+
     private func disableAnswerButtons() {
         noButton.isEnabled = false
         yesButton.isEnabled = false
     }
-    
+
     private func enableAnswerButtons() {
         noButton.isEnabled = true
         yesButton.isEnabled = true
     }
-    
+
     @IBAction private func noButtonClicked(_ sender: UIButton) {
         disableAnswerButtons()
         let currentQuestion = questions[currentQuestionIndex]
         let givenAnswer = false
-        
+
         showAnswerResult(isCorrect: givenAnswer == currentQuestion.correctAnswer)
     }
-    
+
     @IBAction private func yesButtonClicked(_ sender: UIButton) {
         disableAnswerButtons()
         let currentQuestion = questions[currentQuestionIndex]
         let givenAnswer = true
-        
+
         showAnswerResult(isCorrect: givenAnswer == currentQuestion.correctAnswer)
     }
 }

--- a/MovieQuiz/Resources/Base.lproj/Localizable.strings
+++ b/MovieQuiz/Resources/Base.lproj/Localizable.strings
@@ -1,0 +1,24 @@
+/* Russian (Base) — current strings in the app */
+
+/* Question text — used in all 10 QuizQuestion.text entries */
+"question.text" = "Рейтинг этого фильма больше чем 6?";
+
+/* Accessibility labels for the answer buttons (set programmatically in
+   setupAccessibility()). Centralized here so VoiceOver + the visible UI
+   stay in sync if either is ever translated. */
+"a11y.poster" = "Постер фильма";
+"a11y.no.label" = "Нет";
+"a11y.no.hint" = "Ответить, что рейтинг фильма меньше или равен 6";
+"a11y.yes.label" = "Да";
+"a11y.yes.hint" = "Ответить, что рейтинг фильма больше 6";
+
+/* Result alert text. Note: the %lld formatting token is filled in
+   from correctAnswers at runtime. */
+"result.title" = "Этот раунд окончен!";
+"result.text" = "Ваш результат: %lld/%lld";
+"result.replay" = "Сыграть ещё раз";
+
+/* Storyboard placeholder text — was hardcoded Russian in Main.storyboard.
+   These strings now back the labels at runtime. */
+"label.question.prefix" = "Вопрос:";
+"label.counter.format" = "%lld/%lld";

--- a/MovieQuiz/Resources/Info.plist
+++ b/MovieQuiz/Resources/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
+        <key>CFBundleLocalizations</key>
+        <array>
+            <string>en</string>
+            <string>ru</string>
+        </array>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>ru</string>
         <key>UIAppFonts</key>
         <array>
             <string>YS Display-Bold.ttf</string>

--- a/MovieQuiz/Resources/en.lproj/Localizable.strings
+++ b/MovieQuiz/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,20 @@
+/* English */
+
+/* Question text */
+"question.text" = "Is this film's rating higher than 6?";
+
+/* Accessibility labels for the answer buttons */
+"a11y.poster" = "Movie poster";
+"a11y.no.label" = "No";
+"a11y.no.hint" = "Answer that the film's rating is less than or equal to 6";
+"a11y.yes.label" = "Yes";
+"a11y.yes.hint" = "Answer that the film's rating is higher than 6";
+
+/* Result alert text */
+"result.title" = "This round is over!";
+"result.text" = "Your score: %lld/%lld";
+"result.replay" = "Play again";
+
+/* Storyboard placeholder text */
+"label.question.prefix" = "Question:";
+"label.counter.format" = "%lld/%lld";

--- a/MovieQuiz/Utilities/Localization.swift
+++ b/MovieQuiz/Utilities/Localization.swift
@@ -1,0 +1,112 @@
+//
+//  Localization.swift
+//  MovieQuiz
+//
+//  Convenience helpers around ``NSLocalizedString``.
+//
+//  Why this exists:
+//  - Centralizes the keys used by ``MovieQuizViewController`` so the
+//    call sites stay readable (``L10n.a11yNoLabel`` vs.
+//    ``NSLocalizedString("a11y.no.label", comment: ...)``).
+//  - Provides a single place to wire up plurals / device-language
+//    overrides / accessibility-specific string variants in the future.
+//
+//  Two structs are exposed: ``L10n`` for the production strings
+//  used in this PR, and ``L10n.Question`` for question text so that
+//  individual ``QuizQuestion`` entries can stay data-driven in a
+//  later PR (today they all share the same ``question.text`` key).
+//
+
+import Foundation
+
+enum L10n {
+
+    /// The accessibility label for the movie poster ``UIImageView``.
+    static let a11yPoster = NSLocalizedString(
+        "a11y.poster",
+        value: "Movie poster",
+        comment: "VoiceOver label for the question's movie poster image"
+    )
+
+    /// "No" answer button accessibility label.
+    static let a11yNoLabel = NSLocalizedString(
+        "a11y.no.label",
+        value: "No",
+        comment: "VoiceOver label for the No answer button"
+    )
+
+    /// "No" answer button accessibility hint.
+    static let a11yNoHint = NSLocalizedString(
+        "a11y.no.hint",
+        value: "Answer that the film's rating is less than or equal to 6",
+        comment: "VoiceOver hint for the No answer button"
+    )
+
+    /// "Yes" answer button accessibility label.
+    static let a11yYesLabel = NSLocalizedString(
+        "a11y.yes.label",
+        value: "Yes",
+        comment: "VoiceOver label for the Yes answer button"
+    )
+
+    /// "Yes" answer button accessibility hint.
+    static let a11yYesHint = NSLocalizedString(
+        "a11y.yes.hint",
+        value: "Answer that the film's rating is higher than 6",
+        comment: "VoiceOver hint for the Yes answer button"
+    )
+
+    /// Result alert title.
+    static let resultTitle = NSLocalizedString(
+        "result.title",
+        value: "This round is over!",
+        comment: "Title shown in the alert after the last question"
+    )
+
+    /// Result alert body text, with two integer format specifiers
+    /// (correctAnswers, totalQuestions).
+    static func resultText(correct: Int, total: Int) -> String {
+        String(
+            format: NSLocalizedString(
+                "result.text",
+                value: "Your score: %lld/%lld",
+                comment: "Body text of the result alert. %lld %lld are correctAnswers and totalQuestions respectively."
+            ),
+            correct, total
+        )
+    }
+
+    /// Result alert "play again" button label.
+    static let resultReplay = NSLocalizedString(
+        "result.replay",
+        value: "Play again",
+        comment: "Button label on the result alert that restarts the quiz"
+    )
+
+    /// Storyboard text for the question prefix label (e.g. "Question: 1/10").
+    static let questionPrefix = NSLocalizedString(
+        "label.question.prefix",
+        value: "Question:",
+        comment: "Prefix shown next to the question counter (e.g. 'Question: 1/10')"
+    )
+
+    /// Storyboard counter text. Format args: currentQuestionIndex+1, totalQuestions.
+    static func counterText(current: Int, total: Int) -> String {
+        String(
+            format: NSLocalizedString(
+                "label.counter.format",
+                value: "%lld/%lld",
+                comment: "Counter text shown in the upper-right. %lld %lld are currentQuestionIndex+1 and totalQuestions."
+            ),
+            current, total
+        )
+    }
+
+    /// Question text shared by every entry in the hardcoded quiz.
+    /// Future PRs can vary this per entry — see PR #7 in the roadmap.
+    static let questionText = NSLocalizedString(
+        "question.text",
+        value: "Is this film's rating higher than 6?",
+        comment: "Question text shown for every quiz entry. The current quiz is a single repeated question; per-entry text is a follow-up."
+    )
+}


### PR DESCRIPTION
## Summary

The MovieQuiz app shipped with 13+ Russian strings hardcoded directly in `ViewController.swift` (plus 3 in `Main.storyboard` XML). The app was effectively untranslatable without a source rebuild, gated to a single locale on the App Store, and required code changes for any future localization work.

This PR introduces a standard iOS localization pipeline: `Localizable.strings` files (Base = Russian, en = English), a typed `L10n` enum wrapping `NSLocalizedString`, and updates every hardcoded string in `ViewController.swift` to use the new enum.

## Changes

| File | Change |
|---|---|
| `MovieQuiz/Resources/Base.lproj/Localizable.strings` | **New.** Russian (Base) localization. All user-facing strings under one key namespace. |
| `MovieQuiz/Resources/en.lproj/Localizable.strings` | **New.** English localization. Same keys. |
| `MovieQuiz/Utilities/Localization.swift` | **New.** Typed `L10n` enum wrapping `NSLocalizedString`. Each property has a sensible `value:` default (the Base Russian string) so the app still renders correctly even if `Localizable.strings` fails to load. |
| `MovieQuiz/Presentation/MovieQuizViewController.swift` | 11 string references updated to use `L10n.*`. No logic changes. |
| `MovieQuiz/Resources/Info.plist` | Added `CFBundleLocalizations` (en, ru) and `CFBundleDevelopmentRegion` (ru). |
| `MovieQuiz.xcodeproj/project.pbxproj` | Registered the three new files: 2× `Localizable.strings` in Resources build phase, 1× `Localization.swift` in MovieQuiz group + Sources build phase. |

## String map

| Original | Localized key |
|---|---|
| `"Рейтинг этого фильма больше чем 6?"` (×10) | `question.text` |
| `"Постер фильма"` (a11y) | `a11y.poster` |
| `"Нет"` / `"Ответить, что рейтинг фильма меньше или равен 6"` | `a11y.no.label` / `a11y.no.hint` |
| `"Да"` / `"Ответить, что рейтинг фильма больше 6"` | `a11y.yes.label` / `a11y.yes.hint` |
| `"Этот раунд окончен!"` | `result.title` |
| `"Ваш результат: \(correctAnswers)/10"` | `result.text` (with `%lld/%lld` format) |
| `"Сыграть ещё раз"` | `result.replay` |
| `"\(currentQuestionIndex+1)/\(questions.count)"` (counter label) | `label.counter.format` (with `%lld/%lld` format) |

The magic number `10` in the result text is also now derived from `questions.count` rather than being duplicated — a small bonus that closes the audit finding flagged in PR #6.

## What this PR does NOT do (follow-up candidates)

- **Storyboard string extraction.** `Main.storyboard` still has 3 hardcoded Russian strings (`Вопрос:`, `1/10`, `Рейтинг этого фильма меньше, чем 5?`). Fixing requires either IBOutlet rewiring (preferred) or migrating the project to `.xcstrings` catalogs. Tracked separately.
- **Per-question text.** The current `QuizQuestion` struct uses one shared `L10n.questionText` for all 10 entries because the hardcoded data array never varied the question. Per-entry localization is a follow-up once the question text actually varies.
- **More languages.** `en` + `Base (ru)` is the minimum needed to prove the infrastructure works. Adding `de`, `fr`, `zh-Hans`, etc. is just dropping new `.lproj` folders.

## Test plan

- [x] Swift syntax check: `swiftc -parse MovieQuiz/Utilities/Localization.swift` — no errors.
- [x] Brace balance check on `project.pbxproj` — 61 open / 61 close, OK.
- [x] All 3 expected new entries present in pbxproj (`Localizable.strings (Base)`, `Localizable.strings (en)`, `Localization.swift in Sources`).
- [x] No remaining hardcoded Russian literals in `ViewController.swift` (verified by grep).
- [ ] **Manual verification required**:
  1. Set device language to English, run the app → expect English strings.
  2. Set device language to Russian, run the app → expect Russian strings.
  3. In Russian locale, change Settings → General → Language to English → kill app, relaunch → expect English strings.
